### PR TITLE
fix: fix plugin step is empty when without plugin component when create cluster

### DIFF
--- a/src/components/StepForm/index.jsx
+++ b/src/components/StepForm/index.jsx
@@ -346,7 +346,6 @@ export default class BaseStepForm extends React.Component {
 
   render() {
     const { current } = this.state;
-
     return (
       <div className={classnames(styles.wrapper, this.className)}>
         <Spin spinning={this.isSubmitting}>

--- a/src/components/StepForm/steps.jsx
+++ b/src/components/StepForm/steps.jsx
@@ -33,6 +33,6 @@ export default function MStep(props) {
         </Steps>
       </div>
     ),
-    [current]
+    [current, steps]
   );
 }

--- a/src/pages/cluster/components/PluginForm/index.jsx
+++ b/src/pages/cluster/components/PluginForm/index.jsx
@@ -20,7 +20,7 @@ import Tabs from 'components/Tabs';
 import { cloneDeep, isEmpty, get, set, isMatch } from 'lodash';
 import RenderForm from './RenderForm';
 import { Context } from './Context';
-import KubesphereTips from 'pages/cluster/components/KubesphereTips';
+import Tips from 'pages/cluster/components/Tips';
 
 const PluginForm = (props) => {
   const {
@@ -33,7 +33,7 @@ const PluginForm = (props) => {
     onChange,
   } = props;
   const enabledStorageClass = get(context, 'storage.enableStorage') || [];
-  const modules = components.filter((m) => m.name === 'kubesphere');
+  const modules = components.filter((m) => m.category !== 'storage');
 
   const [state, setState] = useReducer(
     (_state, newState) => ({ ..._state, ...newState }),
@@ -177,6 +177,34 @@ const PluginForm = (props) => {
 
   if (isEmpty(tabs)) return null;
 
+  const TabItem = ({ tab }) => (
+    <>
+      {tab.category === 'paas' && <Tips />}
+      <ItemForm tab={tab} />
+    </>
+  );
+
+  const ItemForm = ({ tab }) => {
+    if (
+      isEmpty(enabledStorageClass) &&
+      (tab?.dependence || []).includes('storage')
+    ) {
+      return null;
+    }
+
+    return (
+      <RenderForm
+        schema={tab.schema}
+        name={current}
+        value={tab.formData || {}}
+        onChange={(name, formInstance, formData) =>
+          handleFRChange(name, formInstance, formData)
+        }
+        onMount={onMount}
+      />
+    );
+  };
+
   return (
     <Context.Provider value={{ context, updateContext }}>
       <Tabs
@@ -186,20 +214,7 @@ const PluginForm = (props) => {
         styles={{ paddingLeft: '10px' }}
       >
         {tabs.map((tab) => (
-          <>
-            <KubesphereTips />
-            {!isEmpty(enabledStorageClass) && (
-              <RenderForm
-                schema={tab.schema}
-                name={current}
-                value={tab.formData || {}}
-                onChange={(name, formInstance, formData) =>
-                  handleFRChange(name, formInstance, formData)
-                }
-                onMount={onMount}
-              />
-            )}
-          </>
+          <TabItem tab={tab} />
         ))}
       </Tabs>
     </Context.Provider>

--- a/src/pages/cluster/components/PluginForm/storageFrom.jsx
+++ b/src/pages/cluster/components/PluginForm/storageFrom.jsx
@@ -27,7 +27,7 @@ import { useRootStore } from 'stores';
 
 import styles from './index.less';
 
-const PluginForm = (props) => {
+const StorageForm = (props) => {
   const {
     templates = [],
     useTemplate = false,
@@ -303,4 +303,4 @@ const PluginForm = (props) => {
   );
 };
 
-export default observer(PluginForm);
+export default observer(StorageForm);

--- a/src/pages/cluster/components/Tips/index.jsx
+++ b/src/pages/cluster/components/Tips/index.jsx
@@ -17,7 +17,7 @@
 import React from 'react';
 import Tips from 'components/Tips';
 
-const KubesphereTips = () => {
+export default () => {
   const data = [
     {
       content: t('1. At least one storage is required to install PaaS.'),
@@ -51,5 +51,3 @@ const KubesphereTips = () => {
     />
   );
 };
-
-export default KubesphereTips;

--- a/src/pages/cluster/containers/Cluster/actions/AddPlugin.jsx
+++ b/src/pages/cluster/containers/Cluster/actions/AddPlugin.jsx
@@ -21,7 +21,7 @@ import classnames from 'classnames';
 import styles from './index.less';
 import RenderForm from '../../../components/PluginForm/RenderForm';
 import { Context } from 'pages/cluster/components/PluginForm/Context';
-import KubesphereTips from 'pages/cluster/components/KubesphereTips';
+import Tips from '@/pages/cluster/components/Tips';
 import Notify from 'components/Notify';
 
 import Tabs from 'components/Tabs';
@@ -179,7 +179,7 @@ const Plugin = (props) => {
         {tabs.map((item) =>
           item.schemas.map((_item, _index) => (
             <>
-              {item.name === 'kubesphere' && <KubesphereTips />}
+              {item.name === 'kubesphere' && <Tips />}
               <RenderForm
                 schema={_item}
                 name={current}

--- a/src/pages/cluster/containers/Cluster/actions/Create/Confirm.jsx
+++ b/src/pages/cluster/containers/Cluster/actions/Create/Confirm.jsx
@@ -329,6 +329,17 @@ export class ConfirmStep extends BaseForm {
     return result;
   };
 
+  get hasPlugin() {
+    const {
+      context: { components },
+    } = this.props;
+    const hasPlugin =
+      (components || []).filter(({ category }) => category !== 'storage')
+        .length > 0;
+
+    return hasPlugin;
+  }
+
   get formItems() {
     const { context } = this.props;
     const { name, templateName } = context;
@@ -397,17 +408,19 @@ export class ConfirmStep extends BaseForm {
           items: this.getStorageItems(),
         },
       ],
-      [
-        {
-          name: 'plugin',
-          type: 'descriptions',
-          title: t('Plugins Config'),
-          onClick: () => {
-            this.goStep(3);
-          },
-          items: this.getPluginsItems(),
-        },
-      ],
+      ...(this.hasPlugin
+        ? [
+            {
+              name: 'plugin',
+              type: 'descriptions',
+              title: t('Plugins Config'),
+              onClick: () => {
+                this.goStep(3);
+              },
+              items: this.getPluginsItems(),
+            },
+          ]
+        : []),
     ];
   }
 }

--- a/src/pages/cluster/containers/Cluster/actions/Create/Storage.jsx
+++ b/src/pages/cluster/containers/Cluster/actions/Create/Storage.jsx
@@ -18,7 +18,7 @@ import { observer } from 'mobx-react';
 import Base from 'components/Form';
 import { rootStore } from 'stores';
 import { filter } from 'lodash';
-import StorageForm from 'pages/cluster/components/PluginForm/storageFrom';
+import StorageForm from 'pages/cluster/components/PluginForm/StorageFrom';
 
 @observer
 export default class Storage extends Base {

--- a/src/pages/cluster/containers/Cluster/actions/Create/index.jsx
+++ b/src/pages/cluster/containers/Cluster/actions/Create/index.jsx
@@ -62,6 +62,15 @@ export default class Create extends StepAction {
     return 'cluster-create';
   }
 
+  get hasPlugin() {
+    const hasPlugin =
+      (this.store?.components || []).filter(
+        ({ category }) => category !== 'storage'
+      ).length > 0;
+
+    return hasPlugin;
+  }
+
   get steps() {
     return [
       {
@@ -76,10 +85,14 @@ export default class Create extends StepAction {
         title: t('Storage Config'),
         component: Storage,
       },
-      {
-        title: t('Plugin Manage'),
-        component: Plugin,
-      },
+      ...(this.hasPlugin
+        ? [
+            {
+              title: t('Plugin Manage'),
+              component: Plugin,
+            },
+          ]
+        : []),
       {
         title: t('Confirm Config'),
         component: Confirm,
@@ -293,9 +306,6 @@ export default class Create extends StepAction {
         components: this.getComponents(values),
       },
     };
-
-    // eslint-disable-next-line no-console
-    console.log('params', params);
 
     return this.store.create(params);
   };

--- a/src/pages/cluster/containers/Template/cluster/actions/Create/Storage.jsx
+++ b/src/pages/cluster/containers/Template/cluster/actions/Create/Storage.jsx
@@ -19,7 +19,7 @@ import Base from 'components/Form';
 import { rootStore } from 'stores';
 import { toJS } from 'mobx';
 import { filter } from 'lodash';
-import StorageForm from 'pages/cluster/components/PluginForm/storageFrom';
+import StorageForm from 'pages/cluster/components/PluginForm/StorageFrom';
 
 @observer
 export default class Storage extends Base {

--- a/src/pages/cluster/containers/Template/plugin/actions/Create.jsx
+++ b/src/pages/cluster/containers/Template/plugin/actions/Create.jsx
@@ -20,7 +20,7 @@ import { set, cloneDeep } from 'lodash';
 import classnames from 'classnames';
 import RenderForm from 'pages/cluster/components/PluginForm/RenderForm';
 import { Context } from 'pages/cluster/components/PluginForm/Context';
-import KubesphereTips from 'pages/cluster/components/KubesphereTips';
+import Tips from '@/pages/cluster/components/Tips';
 
 import Notify from 'components/Notify';
 import Footer from 'components/Footer';
@@ -42,7 +42,7 @@ const Plugin = (props) => {
 
   return (
     <Context.Provider value={{ context: setState }}>
-      {current === 'kubesphere' && <KubesphereTips />}
+      {current === 'kubesphere' && <Tips />}
       <RenderForm
         schema={currentPlugin?.schema}
         name={currentPlugin?.name}

--- a/src/stores/cluster.js
+++ b/src/stores/cluster.js
@@ -71,7 +71,6 @@ class ClusterStore extends BaseStore {
     );
     const data = result;
     this.components = data || [];
-
     return data;
   }
 


### PR DESCRIPTION
Signed-off-by: moweiwei <mo.weiwei@99cloud.net>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #17 

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```