### PR TITLE
fix createQuickly in create cluster

### DIFF
--- a/src/components/StepForm/footer.jsx
+++ b/src/components/StepForm/footer.jsx
@@ -75,7 +75,9 @@ export default function Footer(props) {
   };
 
   const CreateQuickly = () => {
-    if (isCreateQuickly && current !== steps.length - 1) {
+    const isFirstStep = current === 0;
+    const isEndStep = current === steps.length - 1;
+    if (isCreateQuickly && !isFirstStep && !isEndStep) {
       return (
         <Button type="primary" onClick={onClickCreateQuickly}>
           {t('Create Quickly')}

--- a/src/components/StepForm/index.jsx
+++ b/src/components/StepForm/index.jsx
@@ -305,7 +305,7 @@ export default class BaseStepForm extends React.Component {
   };
 
   onClickCreateQuickly = async () => {
-    const lastLength = this.formRefs.length - 1 - this.state.current;
+    const lastLength = this.steps.length - 1 - this.state.current;
     for (let i = 0; i < lastLength; i++) {
       // eslint-disable-next-line no-await-in-loop
       const result = await this.onClickNextForAsync();

--- a/src/pages/cluster/containers/Cluster/actions/Create/index.jsx
+++ b/src/pages/cluster/containers/Cluster/actions/Create/index.jsx
@@ -46,8 +46,7 @@ export default class Create extends StepAction {
   }
 
   get isCreateQuickly() {
-    const { useTemplate = false } = this.state.data;
-    return useTemplate;
+    return true;
   }
 
   get listUrl() {


### PR DESCRIPTION
Signed-off-by: liuying <liu.ying@99cloud.net>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #51 

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```