### PR TITLE
fix backup does not display the k8s version and edit backup

### DIFF
--- a/src/pages/cluster/containers/Cluster/Detail/Backup/actions/Edit.jsx
+++ b/src/pages/cluster/containers/Cluster/Detail/Backup/actions/Edit.jsx
@@ -72,7 +72,11 @@ class Edit extends ModalAction {
     const { id: cluster } = this.containerProps.detail;
     const { description } = values;
 
-    set(formTemplate, 'description', description);
+    set(
+      formTemplate,
+      'metadata.annotations["kubeclipper.io/description"]',
+      description
+    );
 
     return this.store.edit(
       { id: name, cluster, resourceVersion },

--- a/src/pages/cluster/containers/Cluster/actions/Backup.jsx
+++ b/src/pages/cluster/containers/Cluster/actions/Backup.jsx
@@ -111,7 +111,11 @@ export default class Backup extends ModalAction {
     const formTemplate = FORM_TEMPLATES.backups();
 
     set(formTemplate, 'metadata.name', name);
-    set(formTemplate, 'description', description);
+    set(
+      formTemplate,
+      'metadata.annotations["kubeclipper.io/description"]',
+      description
+    );
 
     return this.store.create(formTemplate, { cluster: this.cluster });
   };

--- a/src/utils/object.mapper.js
+++ b/src/utils/object.mapper.js
@@ -326,6 +326,8 @@ const BackUpMapper = (item) => ({
   ...item,
   ...getBaseInfo(item),
   status: get(item, 'backupStatus.status'),
+  kubernetesVersion: get(item, 'backupStatus.kubernetesVersion'),
+  description: get(item, 'metadata.annotations["kubeclipper.io/description"]'),
   cluster: get(item, 'metadata.labels["kubeclipper.io/cluster"]'),
   _originData: getOriginData(item),
 });


### PR DESCRIPTION
Signed-off-by: liuying <liu.ying@99cloud.net>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #55 

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```