### PR TITLE
fix the plugin data is not cached after the  next step during create cluster

### DIFF
--- a/src/pages/cluster/components/plugin/PluginForm.jsx
+++ b/src/pages/cluster/components/plugin/PluginForm.jsx
@@ -101,7 +101,11 @@ const PluginForm = (props) => {
       };
     });
 
-    setState({ ...state, tabs: newTabs, current: modules[0]?.name });
+    if (context?.plugins?.state) {
+      setState(context.plugins.state);
+    } else {
+      setState({ ...state, tabs: newTabs, current: modules[0]?.name });
+    }
   }, []);
 
   const handleTabChange = (tab, index) => {
@@ -155,10 +159,7 @@ const PluginForm = (props) => {
 
     const forms = cloneDeep(value?.forms) || {};
     forms[name] = formInstance;
-    onChange({ forms, currentForms: formInstance });
-    updateContext({
-      plugins: { forms, currentForms: formInstance },
-    });
+    onChange({ forms, currentForms: formInstance, state });
   };
 
   /**

--- a/src/utils/object.mapper.js
+++ b/src/utils/object.mapper.js
@@ -209,7 +209,7 @@ const ClusterTemplateMapper = (item) => {
     IPv6AutoDetection: get(config, 'cni.calico.IPv6AutoDetection'),
     calicoMode: get(config, 'cni.calico.mode'),
     IPManger: get(config, 'cni.calico.IPManger'),
-    availableComponents: get(config, 'components'),
+    availableComponents: get(config, 'addons'),
     ...podNetwork,
     _originData: item,
   };


### PR DESCRIPTION
Signed-off-by: liuying <liu.ying@99cloud.net>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #57 

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```