### PR TITLE
fix: remove addplugin action when components no pligun

### DIFF
--- a/src/components/Tables/Base/ItemAction/index.jsx
+++ b/src/components/Tables/Base/ItemAction/index.jsx
@@ -18,6 +18,7 @@ import { useRootStore } from 'stores';
 import { getAllowedResults, getActionList } from 'utils/allowed';
 import { useDeepCompareEffect } from 'hooks';
 import DropdownActions from './DropdownActions';
+import { observer } from 'mobx-react';
 
 const ItemAction = ({
   actions,
@@ -27,7 +28,7 @@ const ItemAction = ({
   firstActionClassName,
 }) => {
   const [results, setResults] = useState([]);
-  const { routing } = useRootStore();
+  const { routing, hasPlugin } = useRootStore();
 
   const { actionList, firstAction, moreActions } = getActionList(
     actions,
@@ -47,7 +48,7 @@ const ItemAction = ({
     }
 
     updateResult();
-  }, [containerProps, item]);
+  }, [containerProps, item, hasPlugin]);
 
   return (
     <DropdownActions
@@ -63,4 +64,4 @@ const ItemAction = ({
   );
 };
 
-export default ItemAction;
+export default observer(ItemAction);

--- a/src/layouts/Base/index.jsx
+++ b/src/layouts/Base/index.jsx
@@ -38,6 +38,11 @@ function BaseLayout(props) {
   const [state, setState] = useReducer(reducer, initialState);
 
   useEffect(() => {
+    rootStore.fetchComponents();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
     if (!rootStore.user) {
       const user = getLocalStorageItem('user');
 

--- a/src/pages/cluster/containers/Cluster/actions/LinkAddPlugin.jsx
+++ b/src/pages/cluster/containers/Cluster/actions/LinkAddPlugin.jsx
@@ -14,8 +14,9 @@
  *  limitations under the License.
  */
 import { LinkAction } from 'containers/Action';
+import { rootStore } from 'stores';
 
-export default class LinkAddPlugin extends LinkAction {
+class LinkAddPlugin extends LinkAction {
   static title = t('Add Plugin');
 
   static isStatusRunning(item) {
@@ -25,7 +26,12 @@ export default class LinkAddPlugin extends LinkAction {
     return false;
   }
 
-  static allowed = (item) => Promise.resolve(this.isStatusRunning(item));
+  static hasPlugin() {
+    return rootStore.hasPlugin;
+  }
+
+  static allowed = (item) =>
+    Promise.resolve(this.isStatusRunning(item) && this.hasPlugin());
 
   static path(item) {
     return `/cluster/add-plugin/${item.name}`;
@@ -33,3 +39,5 @@ export default class LinkAddPlugin extends LinkAction {
 
   static policy = 'clusters:edit';
 }
+
+export default LinkAddPlugin;

--- a/src/stores/cluster.js
+++ b/src/stores/cluster.js
@@ -64,7 +64,7 @@ export default class ClusterStore extends BaseStore {
     return res;
   }
 
-  async fetchComponents(params) {
+  async fetchComponents(params = {}) {
     let lang = getLocalStorageItem('lang') || 'zh';
     if (lang === 'zh-cn') {
       lang = 'zh';

--- a/src/stores/index.js
+++ b/src/stores/index.js
@@ -22,6 +22,7 @@ import { get, uniq, isArray } from 'lodash';
 import { makeAutoObservable } from 'mobx';
 import ObjectMapper from 'utils/object.mapper';
 import jwtDecode from 'jwt-decode';
+import { APIVERSION } from 'utils/constants';
 import root from './root';
 
 export const routingStore = new RouterStore();
@@ -48,6 +49,10 @@ class RootStore {
   openKeys = [];
 
   config = {};
+
+  components = [];
+
+  hasPlugin = true;
 
   /**
    * routing
@@ -316,6 +321,31 @@ class RootStore {
   async getConfigs() {
     const res = await request.get('/api/config.kubeclipper.io/v1/configz');
     this.config = res;
+  }
+
+  async fetchComponents(params = {}) {
+    let lang = getLocalStorageItem('lang') || 'zh';
+    if (lang === 'zh-cn') {
+      lang = 'zh';
+    }
+    const result = await request.get(
+      `${APIVERSION.config}/components?lang=${lang}`,
+      params
+    );
+    const data = result;
+
+    this.components = data || [];
+    this.updateHasPlugin(data);
+
+    return data;
+  }
+
+  updateHasPlugin(components) {
+    const hasPlugin =
+      components.filter(({ category }) => category !== 'storage').length > 0;
+    this.hasPlugin = hasPlugin;
+
+    return hasPlugin;
   }
 }
 /* Store end */


### PR DESCRIPTION
Signed-off-by: moweiwei <mo.weiwei@99cloud.net>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #89

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```