### PR TITLE
fix the image type can not be saved when saving cluster as a template

### DIFF
--- a/src/pages/cluster/containers/Template/cluster/actions/Create/index.jsx
+++ b/src/pages/cluster/containers/Template/cluster/actions/Create/index.jsx
@@ -199,6 +199,7 @@ export default class Create extends StepAction {
       containerdRootDir,
       containerdVersionOnline,
       containerdVersionOffline,
+      backupPoint,
       // backupPoint,
       // network
       dnsDomain,
@@ -214,8 +215,8 @@ export default class Create extends StepAction {
       serviceSubnetV6,
       mtu,
       // cluster
-      // description,
-      // externalIP,
+      description,
+      externalIP,
       // labels,
     } = values;
 
@@ -225,8 +226,22 @@ export default class Create extends StepAction {
     const { IPv4AutoDetection, IPv6AutoDetection } =
       computeAutoDetection(values);
 
+    const offlineAnnotations = offline ? { 'kubeclipper.io/offline': '' } : {};
+    const externalIPLabel = externalIP
+      ? { 'kubeclipper.io/externalIP': externalIP }
+      : {};
+
     const config = {
-      offline,
+      metadata: {
+        labels: {
+          'kubeclipper.io/backupPoint': backupPoint,
+          ...externalIPLabel,
+        },
+        annotations: {
+          'kubeclipper.io/description': description,
+          ...offlineAnnotations,
+        },
+      },
       certSANs: arrayInputValue(certSANs),
       localRegistry,
       workerNodeVip,

--- a/src/utils/object.mapper.js
+++ b/src/utils/object.mapper.js
@@ -150,9 +150,21 @@ const ClusterTemplateMapper = (item) => {
     config,
     'networking.services.cidrBlocks'
   );
-  const isDualStack = get(item, 'networking.ipFamily') === 'IPv4+IPv6';
+  const isDualStack = get(config, 'networking.ipFamily') === 'IPv4+IPv6';
 
   const offline = has(config.metadata, 'annotations["kubeclipper.io/offline"]');
+  const description = get(
+    config.metadata,
+    'annotations["kubeclipper.io/description"]'
+  );
+  const externalIP = get(
+    config.metadata,
+    'labels["kubeclipper.io/externalIP"]'
+  );
+  const backupPoint = get(
+    config.metadata,
+    'labels["kubeclipper.io/backupPoint"]'
+  );
 
   const kubernetesVersion = get(config, 'kubernetesVersion');
   const kubernetesVersionOnline = !offline && kubernetesVersion;
@@ -163,6 +175,9 @@ const ClusterTemplateMapper = (item) => {
 
   return {
     offline,
+    description,
+    externalIP,
+    backupPoint,
     certSANs: get(config, 'certSANs'),
     localRegistry: get(config, 'localRegistry'),
     workerNodeVip: get(config, 'workerNodeVip'),


### PR DESCRIPTION
Signed-off-by: liuying <liu.ying@99cloud.net>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #76 

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```