### PR TITLE
fix: scheduled backup weekly dictionary error

### DIFF
--- a/src/components/FormItem/SelectCycle/index.jsx
+++ b/src/components/FormItem/SelectCycle/index.jsx
@@ -23,16 +23,16 @@ import {
 const { Option } = Select;
 
 export default function SelectCycle(props) {
-  const { onChange } = props;
+  const { onChange, value } = props;
 
   const [firstLevelSelected, setFirstLevelSelected] = useState(
-    circleDayofFirstLevel[0]
+    value?.firstLevelSelected || circleDayofFirstLevel[0]
   );
   const [secondLevels, setSecondLevels] = useState(
     circleDayofSecondLevel[firstLevelSelected.key]
   );
   const [secondLevelSelected, setSecondLevelSelected] = useState(
-    secondLevels[0]
+    value?.secondLevelSelected || secondLevels[0]
   );
 
   const handleFirstLevelChange = (_, data) => {
@@ -65,7 +65,7 @@ export default function SelectCycle(props) {
       {secondLevels.length ? (
         <Select
           style={{ width: 120, marginLeft: 20 }}
-          value={secondLevelSelected?.value}
+          defaultValue={secondLevelSelected?.label}
           onChange={onSecondLevelChange}
         >
           {secondLevels.map(({ value: _value, label }) => (

--- a/src/pages/cluster/containers/Cluster/Detail/ScheduledBackup/actions/Edit.jsx
+++ b/src/pages/cluster/containers/Cluster/Detail/ScheduledBackup/actions/Edit.jsx
@@ -18,7 +18,8 @@ import moment from 'moment';
 import { ModalAction } from 'containers/Action';
 import { rootStore } from 'stores';
 import { formatCron } from 'utils';
-import { formatFormTemplates } from 'resources/backup';
+import { circleDayofFirstLevel, formatFormTemplates } from 'resources/backup';
+import * as dateOption from 'resources/date';
 
 const { cornBackupStore: store, clusterStore } = rootStore;
 
@@ -59,12 +60,23 @@ class Edit extends ModalAction {
         date: moment(runAt, 'YYYY-MM-DD HH:mm:ss'),
       };
     } else {
-      const { time } = formatCron(schedule);
+      const { time, localsFormat, firstVal } = formatCron(schedule);
+
+      const firstLevelSelected = circleDayofFirstLevel.find(
+        (item) => item.key === localsFormat
+      );
 
       return {
         ...baseDefault,
         time: moment(time, 'HH:mm'),
         maxBackupNum,
+        cycle: {
+          firstLevelSelected,
+          secondLevelSelected: {
+            label: dateOption?.[firstLevelSelected.key]?.[firstVal],
+            value: firstVal,
+          },
+        },
       };
     }
   }

--- a/src/resources/date.jsx
+++ b/src/resources/date.jsx
@@ -29,7 +29,7 @@ export const dayOfWeek = {
   4: t('Thursday'),
   5: t('Friday'),
   6: t('Saturday'),
-  7: t('Sunday'),
+  0: t('Sunday'),
 };
 
 export const dayOfWeekOption = [
@@ -59,7 +59,7 @@ export const dayOfWeekOption = [
   },
   {
     label: t('Sunday'),
-    value: 7,
+    value: 0,
   },
 ];
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -665,6 +665,7 @@ export function formatCron(cron) {
     return {
       cycle: 'Every Month',
       values: dayOfMonth,
+      firstVal: dayOfMonth[0],
       localsFormat: 'dayOfMonth',
       time,
     };
@@ -673,6 +674,7 @@ export function formatCron(cron) {
     return {
       cycle: 'Every Week',
       values: dayOfWeek,
+      firstVal: dayOfWeek[0],
       localsFormat: 'dayOfWeek',
       time,
     };
@@ -680,7 +682,8 @@ export function formatCron(cron) {
   return {
     cycle: 'Every Day',
     values: [],
-    localsFormat: '',
+    firstVal: null,
+    localsFormat: 'day',
     time,
   };
 }


### PR DESCRIPTION
Signed-off-by: liuying <liu.ying@99cloud.net>

<!-- Thanks for sending a pull request! Here are some tips for you:

1. If you want **faster** PR reviews, read how: https://github.com/kubesphere/community/blob/master/developer-guide/development/the-pr-author-guide-to-getting-through-code-review.md
2. In case you want to know how your PR got reviewed, read: https://github.com/kubesphere/community/blob/master/developer-guide/development/code-review-guide.md
3. Here are some coding convetions followed by KubeSphere community: https://github.com/kubesphere/community/blob/master/developer-guide/development/coding-conventions.md
-->

### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->


### What this PR does / why we need it:

### Which issue(s) this PR fixes:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #110 

### Special notes for reviewers:
```
```

### Does this PR introduced a user-facing change?
<!--
If no, just write "None" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://github.com/kubernetes/community/blob/master/contributors/guide/release-notes.md
-->
```release-note

```

### Additional documentation, usage docs, etc.:
<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```